### PR TITLE
feat: add Mixpanel analytics tracking

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,13 +1,31 @@
 <script lang="ts" setup>
 
 import { useHead, useSeoMeta } from '#app'
+import { onMounted, onBeforeUnmount } from 'vue'
 
 const { $mixpanel } = useNuxtApp()
-const router = useRouter()
 
-router.afterEach((to) => {
-  $mixpanel.track('Page View', { path: to.path, name: String(to.name ?? '') })
+const scrollThresholds = [25, 50, 75, 100]
+const firedThresholds = new Set<number>()
+
+function handleScroll() {
+  const doc = document.documentElement
+  const scrollable = doc.scrollHeight - doc.clientHeight
+  if (scrollable <= 0) return
+  const pct = Math.round(((window.scrollY || doc.scrollTop) / scrollable) * 100)
+  for (const t of scrollThresholds) {
+    if (pct >= t && !firedThresholds.has(t)) {
+      firedThresholds.add(t)
+      $mixpanel.track('scroll_depth_reached', { depth_percentage: t })
+    }
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', handleScroll, { passive: true })
+  handleScroll()
 })
+onBeforeUnmount(() => window.removeEventListener('scroll', handleScroll))
 
 useSeoMeta({
   ogImage: 'https://res.cloudinary.com/dawr8i20o/image/upload/c_scale,f_webp,w_910/v1725092932/claranceliberi.me/Liberi_profile_pic_2_-min_rxo6gw.webp',

--- a/app.vue
+++ b/app.vue
@@ -2,6 +2,13 @@
 
 import { useHead, useSeoMeta } from '#app'
 
+const { $mixpanel } = useNuxtApp()
+const router = useRouter()
+
+router.afterEach((to) => {
+  $mixpanel.track('Page View', { path: to.path, name: String(to.name ?? '') })
+})
+
 useSeoMeta({
   ogImage: 'https://res.cloudinary.com/dawr8i20o/image/upload/c_scale,f_webp,w_910/v1725092932/claranceliberi.me/Liberi_profile_pic_2_-min_rxo6gw.webp',
   twitterTitle: 'Clarance Liberi',

--- a/data/index.ts
+++ b/data/index.ts
@@ -12,7 +12,8 @@ export const books: Book[] = [
     title: 'Sarrounded By Idiots',
     author: 'T. Erikson',
     cover: 'https://res.cloudinary.com/dawr8i20o/image/upload/c_scale,f_webp,w_180/v1725100328/claranceliberi.me/books/sarrounded-by-idiots.webp',
-    status: 'READ'
+    status: 'READ',
+    rating: 3
   }
 ]
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@nuxtjs/google-fonts": "^3.2.0",
     "@nuxtjs/seo": "^2.0.0-rc.19",
     "@nuxtjs/tailwindcss": "^6.12.1",
+    "@types/mixpanel-browser": "^2.66.0",
     "@unocss/nuxt": "^0.62.3",
     "eslint": "^9.9.1",
     "eslint-config-prettier": "^9.1.0",
@@ -28,7 +29,8 @@
     "unocss": "^0.62.3"
   },
   "dependencies": {
-    "@nuxtjs/robots": "^4.1.3"
+    "@nuxtjs/robots": "^4.1.3",
+    "mixpanel-browser": "^2.78.0"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/plugins/mixpanel.client.ts
+++ b/plugins/mixpanel.client.ts
@@ -1,0 +1,13 @@
+import mixpanel from 'mixpanel-browser'
+
+export default defineNuxtPlugin(() => {
+  mixpanel.init('92b694410fc0c77b742d59416933ed81', {
+    debug: process.env.NODE_ENV !== 'production',
+    track_pageview: false,
+    persistence: 'localStorage',
+  })
+
+  return {
+    provide: { mixpanel },
+  }
+})

--- a/plugins/mixpanel.client.ts
+++ b/plugins/mixpanel.client.ts
@@ -2,6 +2,7 @@ import mixpanel from 'mixpanel-browser'
 
 export default defineNuxtPlugin(() => {
   mixpanel.init('92b694410fc0c77b742d59416933ed81', {
+    api_host: 'https://api-eu.mixpanel.com',
     debug: process.env.NODE_ENV !== 'production',
     track_pageview: true,
     persistence: 'localStorage',

--- a/plugins/mixpanel.client.ts
+++ b/plugins/mixpanel.client.ts
@@ -6,6 +6,16 @@ export default defineNuxtPlugin(() => {
     debug: process.env.NODE_ENV !== 'production',
     track_pageview: true,
     persistence: 'localStorage',
+    record_sessions_percent: 100,
+    record_mask_text_selector: '',
+  })
+
+  mixpanel.identify(mixpanel.get_distinct_id())
+  const now = new Date().toISOString()
+  mixpanel.people.set_once({ first_seen_at: now })
+  mixpanel.people.set({
+    last_seen_at: now,
+    referrer: document.referrer || 'direct',
   })
 
   return {

--- a/plugins/mixpanel.client.ts
+++ b/plugins/mixpanel.client.ts
@@ -3,7 +3,7 @@ import mixpanel from 'mixpanel-browser'
 export default defineNuxtPlugin(() => {
   mixpanel.init('92b694410fc0c77b742d59416933ed81', {
     debug: process.env.NODE_ENV !== 'production',
-    track_pageview: false,
+    track_pageview: true,
     persistence: 'localStorage',
   })
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,5 +20,6 @@ export interface Book {
     title: string
     author: string
     cover: string
-    status: 'READING' | 'READ'
+    status: 'READING' | 'READ',
+    rating?: number
 }

--- a/types/mixpanel.d.ts
+++ b/types/mixpanel.d.ts
@@ -1,0 +1,15 @@
+import type { OverridedMixpanel } from 'mixpanel-browser'
+
+declare module '#app' {
+  interface NuxtApp {
+    $mixpanel: OverridedMixpanel
+  }
+}
+
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    $mixpanel: OverridedMixpanel
+  }
+}
+
+export {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,49 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
+"@mixpanel/rrdom@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrdom/-/rrdom-2.0.0-alpha.18.4.tgz#5229dc32d991d6a17870e5033558e9e2be9f1f3c"
+  integrity sha512-58sWLQDPRU0VQn8VzB1tx4ujih9X327Vr6xAzbJ4zge9GENm2L696T4TbWvrRGWPW6w99tHIHbv6SvcLhjjmcQ==
+  dependencies:
+    "@mixpanel/rrweb-snapshot" "^2.0.0-alpha.18"
+
+"@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.4":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.4.tgz#674c3d0292fed17ab57c9c5681d9f5669f9198ff"
+  integrity sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==
+
+"@mixpanel/rrweb-snapshot@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.4.tgz#80685f81f22b4a0aaa96625c164f738da2da1642"
+  integrity sha512-ubLGwgPiMMi0rl7zJRh1uMScQ480lT95tkHkIAHkiZOemMY4JSkYZh2v9fpMNwJhaGwB5n/76KI7Cwy8F5qixQ==
+  dependencies:
+    postcss "^8.4.38"
+
+"@mixpanel/rrweb-types@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-types/-/rrweb-types-2.0.0-alpha.18.4.tgz#9290688f03e434b26947f3d8f928cf8dadcc84e3"
+  integrity sha512-7kRuk7pK6Firrb26Mm235Po7s/z+9k0gUKZU/DZkzg5U1yQRcsu4byIrnWTiTQr+LFLUrIiyRKnpGK/QneAhTw==
+
+"@mixpanel/rrweb-utils@2.0.0-alpha.18.4", "@mixpanel/rrweb-utils@^2.0.0-alpha.18":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz#ddf2faada57cd5d4b04894fcae87cfe3b61d919a"
+  integrity sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==
+
+"@mixpanel/rrweb@2.0.0-alpha.18.4":
+  version "2.0.0-alpha.18.4"
+  resolved "https://registry.yarnpkg.com/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz#73a1403e0dc2ed2e35fd35a23ab8efd5c0f7239d"
+  integrity sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==
+  dependencies:
+    "@mixpanel/rrdom" "^2.0.0-alpha.18"
+    "@mixpanel/rrweb-snapshot" "^2.0.0-alpha.18"
+    "@mixpanel/rrweb-types" "^2.0.0-alpha.18"
+    "@mixpanel/rrweb-utils" "^2.0.0-alpha.18"
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    mitt "^3.0.0"
+
 "@netlify/functions@^2.8.0":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-2.8.1.tgz#67cd94f929551e156225fb50d2efba603b97e138"
@@ -1685,6 +1728,11 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/css-font-loading-module@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz#2f98ede46acc0975de85c0b7b0ebe06041d24601"
+  integrity sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
@@ -1711,6 +1759,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/json-logic-js@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-logic-js/-/json-logic-js-2.0.5.tgz#8c2c8a42dc8cc21e2977f64dc7b944cf6479f782"
+  integrity sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==
+
 "@types/json-schema@^7.0.5":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -1722,6 +1775,13 @@
   integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
   dependencies:
     "@types/unist" "*"
+
+"@types/mixpanel-browser@^2.66.0":
+  version "2.66.0"
+  resolved "https://registry.yarnpkg.com/@types/mixpanel-browser/-/mixpanel-browser-2.66.0.tgz#7c2ca33dbd4c40641eb51cc525b83343acee6c11"
+  integrity sha512-07zYZZ9ZVHc7R4ktM+3a2clZvKkj+EJcYZ/FevTs011Fr9tdp59lVgAskMf6ZQUp3lOHLqi7K3f+9QtmEsqh1w==
+  dependencies:
+    mixpanel-browser "*"
 
 "@types/ms@*":
   version "0.7.34"
@@ -2379,6 +2439,11 @@
   dependencies:
     vue-demi ">=0.14.10"
 
+"@xstate/fsm@^1.4.0":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.5.tgz#f599e301997ad7e3c572a0b1ff0696898081bea5"
+  integrity sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -2644,6 +2709,11 @@ bare-stream@^2.0.0:
   integrity sha512-+o9MG5bPRRBlkVSpfFlMag3n7wMaIZb4YZasU2+/96f+3HTQ4F9DKQeu3K/Sjz1W0umu6xvVq1ON0ipWdMlr3A==
   dependencies:
     streamx "^2.18.0"
+
+base64-arraybuffer@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
 base64-js@0.0.8:
   version "0.0.8"
@@ -5033,6 +5103,11 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-logic-js@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/json-logic-js/-/json-logic-js-2.0.5.tgz#55f0c687dd6f56b02ccdcfdd64171ed998ab5499"
+  integrity sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -5904,10 +5979,21 @@ minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-mitt@^3.0.1:
+mitt@^3.0.0, mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
+mixpanel-browser@*, mixpanel-browser@^2.78.0:
+  version "2.78.0"
+  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.78.0.tgz#0b30ab55c227095ac684513f61e45eec615c88d8"
+  integrity sha512-K2nsMLnTK0PXcQxhj1aJyGpKyEfo2u7wgZhVm532DTjkoCbJJkuSjDBWJFCH5agEM5oE0aVoCYKd0hZ+i8LsYw==
+  dependencies:
+    "@mixpanel/rrweb" "2.0.0-alpha.18.4"
+    "@mixpanel/rrweb-plugin-console-record" "2.0.0-alpha.18.4"
+    "@mixpanel/rrweb-utils" "2.0.0-alpha.18.4"
+    "@types/json-logic-js" "2.0.5"
+    json-logic-js "2.0.5"
 
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"


### PR DESCRIPTION
## Summary
- Install `mixpanel-browser` and its type stubs
- Add `plugins/mixpanel.client.ts` — client-only plugin that initialises Mixpanel with the project token
- Track a `Page View` event on every route change via `router.afterEach` in `app.vue`
- Add `types/mixpanel.d.ts` to expose `$mixpanel` to TypeScript

## Test plan
- [ ] Visit the site locally (`yarn dev`) and check the browser network tab for requests to `api.mixpanel.com` (debug mode is on outside production)
- [ ] Verify events appear in the Mixpanel Live View dashboard
- [ ] Confirm navigating between pages fires a new `Page View` event each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)